### PR TITLE
修復Admin後台NoReverseMatch錯誤

### DIFF
--- a/board/admin.py
+++ b/board/admin.py
@@ -81,9 +81,14 @@ class MessageAdmin(admin.ModelAdmin):
     # 添加自定義的 URL 路由
     def get_urls(self):
         urls = super().get_urls()
+        info = self.model._meta.app_label, self.model._meta.model_name
         custom_urls = [
-            path('<int:message_id>/approve/', self.admin_site.admin_view(self.approve_message_view), name='message_approve'), # 更新視圖名稱
-            path('approve_all_pending/', self.admin_site.admin_view(self.approve_all_pending_view), name='approve_all_pending'), # 更新視圖名稱
+            path('<int:message_id>/approve/',
+                 self.admin_site.admin_view(self.approve_message_view),
+                 name=f'{info[0]}_{info[1]}_approve'),
+            path('approve_all_pending/',
+                 self.admin_site.admin_view(self.approve_all_pending_view),
+                 name=f'{info[0]}_{info[1]}_approve_all_pending'),
         ]
         return custom_urls + urls
 


### PR DESCRIPTION
- 修改 MessageAdmin 中的 get_urls 方法，將自定義操作的 URL 名稱 從 'message_approve' 和 'approve_all_pending' 更新為 符合 'app_label_model_name_action' 格式的名稱， 例如 'board_message_approve' 和 'board_message_approve_all_pending'。
- 這解決了在渲染留言更改表單時，由於 {% url opts|admin_urlname:'approve' ... %} 模板標籤無法正確解析 URL 而導致的 NoReverseMatch 錯誤。